### PR TITLE
Add links to Anaconda.org channel and swap ML for Discourse

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,9 @@
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink2">
               <a class="dropdown-item" href="https://github.com/numba/numba">Github</a>
               <a class="dropdown-item" href="https://pypi.org/project/numba/">PyPI</a>
+              <a class="dropdown-item" href="https://anaconda.org/numba/">anaconda.org</a>
               <a class="dropdown-item" href="https://gitter.im/numba/numba">Gitter Chat</a>
-              <a class="dropdown-item" href="https://groups.google.com/a/continuum.io/forum/#!forum/numba-users">Numba Mailing List</a>
+              <a class="dropdown-item" href="https://numba.discourse.group/">Discourse Forum</a>
             </div>
           </li>
 


### PR DESCRIPTION
As title:

- The mailing list is deprecated and Discourse is quite lively.
- If we link to PyPI, it seems worthwhile to link to the  channel as well.