### PR TITLE
Add Mastodon profile verification link

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
     <!-- Custom styles for this template -->
     <link href="_static/main-page.css" rel="stylesheet">
 
+    <!-- Mastodon account verification -->
+    <a rel="me" href="https://fosstodon.org/@numba">Mastodon</a>
   </head>
   <body>
 


### PR DESCRIPTION
This entry in the head of the page enables link verification for the link to this site in the Mastodon account profile. See: https://docs.joinmastodon.org/user/profile/#verification

This will turn the "Website" link in https://fosstodon.org/@numba to "verified" status with a green background and green tick, which provides a little more authenticity to the account.

(Example of a profile with an already-verified website: https://mastodon.social/@gmarkall)