### PR TITLE
Use a link rather than an anchor for Mastodon verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link href="_static/main-page.css" rel="stylesheet">
 
     <!-- Mastodon account verification -->
-    <a rel="me" href="https://fosstodon.org/@numba">Mastodon</a>
+    <link rel="me" href="https://fosstodon.org/@numba" />
   </head>
   <body>
 


### PR DESCRIPTION
I should have used a link in the head to prevent the word "Mastodon" from appearing on the site. See
https://github.com/mastodon/mastodon/issues/10345