### PR TITLE
Add Open Graph meta tags to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!-- open graph -->
     <meta property="og:title" content="Numba: A High Performance Python Compiler" />
     <meta property="og:description" content="Numba is an open source JIT compiler that translates a subset of Python and NumPy code into fast machine code." />
-    <meta property="og:image" content="_static/numba-blue-icon-rgb.svg" />
+    <meta property="og:image" content="https://numba.pydata.org/_static/numba-blue-horizontal-rgb.svg" />
 
     <!-- Bootstrap core CSS -->
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <!-- open graph -->
     <meta property="og:title" content="Numba: A High Performance Python Compiler" />
     <meta property="og:description" content="Numba is an open source JIT compiler that translates a subset of Python and NumPy code into fast machine code." />
-    <meta property="og:image" content="https://numba.pydata.org/_static/numba-blue-horizontal-rgb.svg" />
+    <meta property="og:image" content="/_static/numba-blue-horizontal-rgb.svg" />
 
     <!-- Bootstrap core CSS -->
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
 
     <title>Numba: A High Performance Python Compiler</title>
 
+    <!-- open graph -->
+    <meta property="og:title" content="Numba: A High Performance Python Compiler" />
+    <meta property="og:description" content="Numba is an open source JIT compiler that translates a subset of Python and NumPy code into fast machine code." />
+    <meta property="og:image" content="_static/numba-blue-icon-rgb.svg" />
+
     <!-- Bootstrap core CSS -->
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
 


### PR DESCRIPTION
This pull request adds Open Graph metadata to the `index.html` file to improve how the site appears when shared on social media platforms. These tags help control the title, description, and image preview shown in link previews.

Open Graph enhancements:

* Added `<meta property="og:title">`, `<meta property="og:description">`, and `<meta property="og:image">` tags to specify the site's title, description, and preview image for social sharing.